### PR TITLE
MOD: 修复maven打包后没有把lib中的taobao-sdk带上的bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,13 +36,33 @@
             <groupId>com.dingtalk</groupId>
             <artifactId>dingtalk-api-sdk</artifactId>
             <version>1.0.0-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${pom.basedir}/lib/taobao-sdk-java-auto_1479188381469-20210207.jar</systemPath>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>install-external</id>
+                        <phase>clean</phase>
+                        <configuration>
+                            <file>${pom.basedir}/lib/taobao-sdk-java-auto_1479188381469-20210207.jar</file>
+                            <repositoryLayout>default</repositoryLayout>
+                            <groupId>com.dingtalk</groupId>
+                            <artifactId>dingtalk-api-sdk</artifactId>
+                            <version>1.0.0-SNAPSHOT</version>
+                            <packaging>jar</packaging>
+                            <generatePom>true</generatePom>
+                        </configuration>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>


### PR DESCRIPTION
由于引入的本地包 在IDEA中可以正常运行但是使用 mvn package 打包之后 不会把 lib下的jar包一起打包进来 java -jar 直接执行或者放到docker中运行的时候会出现找不着包的错误

修复之后就可以放到docker里面跑了
